### PR TITLE
fix<Todo>: 修复Todo组件使用回车键创建任务时创建多个

### DIFF
--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -150,11 +150,13 @@ const AddLine = () => {
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    inputRef.current?.addEventListener('keydown', function (event) {
-      if (event.key === 'Enter') {
-        onAdd();
-      }
-    });
+    if(inputRef.current) {
+      inputRef.current.onkeydown = event => {
+        if (event.key === 'Enter') {
+          onAdd();
+        };
+      };  
+    }
   }, [onAdd]);
 
   return (


### PR DESCRIPTION
## 现象
TODO页面使用回车键创建任务时会创建多个(实际上为该任务的字符串长度个)
## 原因 & 解决
AddLine组件中的input的onChange引起重新渲染, onAdd监听的value发生变化, 导致useEffect中的inputRef**不停**添加监听函数, _addEventListenter会不停在该ref上注册事件, value变化多少次, 就添加了多少个监听事件_, 见[DOM0和DOM2事件绑定的区别](https://blog.csdn.net/weixin_30647065/article/details/95502276?spm=1001.2101.3001.6650.11&utm_medium=distribute.pc_relevant.none-task-blog-2%7Edefault%7EBlogCommendFromBaidu%7ERate-11-95502276-blog-80572184.235%5Ev38%5Epc_relevant_anti_t3&depth_1-utm_source=distribute.pc_relevant.none-task-blog-2%7Edefault%7EBlogCommendFromBaidu%7ERate-11-95502276-blog-80572184.235%5Ev38%5Epc_relevant_anti_t3&utm_relevant_index=12)